### PR TITLE
feat: use higher node version in ci/cd

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20.19.2'
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Node.js version used in the release workflow to 20.19.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->